### PR TITLE
Now possible to import without making dbus calls.

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -207,13 +207,15 @@ class NetworkManager(NMDbusInterface):
             return (settings,) + args[1:], kwargs
 
         return args, kwargs
-NetworkManager = NetworkManager()
+if not os.environ.get('LAZY_NETWORKMANAGER'):
+    NetworkManager = NetworkManager()
 
 class Settings(NMDbusInterface):
     interface_name = 'org.freedesktop.NetworkManager.Settings'
     object_path = '/org/freedesktop/NetworkManager/Settings'
     preprocess = NetworkManager.preprocess
-Settings = Settings()
+if not os.environ.get('LAZY_NETWORKMANAGER'):
+    Settings = Settings()
 
 class Connection(NMDbusInterface):
     interface_name = 'org.freedesktop.NetworkManager.Settings.Connection'


### PR DESCRIPTION
This introduces a way of suppressing creating of global variables at import time. Benefits:

- Users of the module can still import as per usual without interruptions as this method is opt-in
- The module can now be imported without calling dbus functions etc by setting the environment variable `LAZY_NETWORKMANAGER`.