### PR TITLE
resolve KeyError

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -139,7 +139,7 @@ class NMDbusInterfaceType(type):
                                 aname = '_' + aname
                             attrs[aname] = type_.make_method(name, element.attrib['name'], item.attrib, list(item))
                         elif item.tag == 'signal':
-                            SignalDispatcher.args[(element.attrib['name'], item.attrib['name'])] = [(arg.attrib['name'], arg.attrib['type']) for arg in item]
+                            SignalDispatcher.args[(element.attrib['name'], item.attrib['name'])] = [(arg.attrib.get('name','unknown'), arg.attrib['type']) for arg in item]
                             attrs['On' + item.attrib['name']] = type_.make_signal(name, element.attrib['name'], item.attrib)
                             attrs['signals'].append(item.attrib['name'])
 
@@ -229,7 +229,7 @@ class NMDbusInterface(object):
                                 aname = '_' + aname
                             setattr(klass, aname, type(klass).make_method(klass.__name__, element.attrib['name'], item.attrib, list(item)))
                         elif item.tag == 'signal':
-                            SignalDispatcher.args[(element.attrib['name'], item.attrib['name'])] = [(arg.attrib['name'], arg.attrib['type']) for arg in item]
+                            SignalDispatcher.args[(element.attrib['name'], item.attrib['name'])] = [(arg.attrib.get('name','unknown'), arg.attrib['type']) for arg in item]
                             setattr(klass, 'On' + item.attrib['name'], type(klass).make_signal(klass.__name__, element.attrib['name'], item.attrib))
                             klass.signals.append(item.attrib['name'])
 


### PR DESCRIPTION
When I called 'import NetworkManager', I observed a KeyError on these lines, caused by an arg that had a 'type' attribute but not a 'name' attribute. 

I don't fully understand this section of code, but I tried debugging a bit. When the KeyError occurred, I printed the other attributes on that line: 

```
Other values when arg.attrib['name'] raised a KeyError:

arg.attrib['type'] = 'o'
element.attrib['name'] = 'org.freedesktop.NetworkManager'
item.attrib['name'] = 'DeviceRemoved'

arg.attrib['type'] = 'o'
element.attrib['name'] = 'org.freedesktop.NetworkManager'
item.attrib['name'] = 'DeviceAdded'

arg.attrib['type'] = 'a{sv}'
element.attrib['name'] = 'org.freedesktop.NetworkManager'
item.attrib['name'] = 'PropertiesChanged'

arg.attrib['type'] = 'u'
element.attrib['name'] = 'org.freedesktop.NetworkManager'
item.attrib['name'] = 'StateChanged'

arg.attrib['type'] = 'o'
element.attrib['name'] = 'org.freedesktop.NetworkManager.Settings'
item.attrib['name'] = 'ConnectionRemoved'

arg.attrib['type'] = 'o'
element.attrib['name'] = 'org.freedesktop.NetworkManager.Settings'
item.attrib['name'] = 'NewConnection'

arg.attrib['type'] = 'a{sv}'
element.attrib['name'] = 'org.freedesktop.NetworkManager.Settings'
item.attrib['name'] = 'PropertiesChanged'
```

The problems occurred on Raspbian when wlan0 was not connected to an access point, and wlan1 was connected. The edits in this PR fixed it, and NetworkManager was still able to control connections, at least to the extent I could test. 

(Also, please let me know if there's a better way to handle this problem than setting name to 'unknown'. I'm new to dbus and NetworkManager.)