### PR TITLE
 Added 6 new device types (in NM_DEVICE_TYPE_..)

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -375,6 +375,12 @@ def device_class(typ):
          NM_DEVICE_TYPE_VXLAN: Vxlan,
          NM_DEVICE_TYPE_WIFI: Wireless,
          NM_DEVICE_TYPE_WIMAX: Wimax,
+         NM_DEVICE_TYPE_MACSEC: MacSec,
+         NM_DEVICE_TYPE_DUMMY: Dummy,
+         NM_DEVICE_TYPE_PPP: PPP,
+         NM_DEVICE_TYPE_OVS_INTERFACE: OvsIf,
+         NM_DEVICE_TYPE_OVS_PORT: OvsPort,
+         NM_DEVICE_TYPE_OVS_BRIDGE: OvsBridge
      }[typ]
 
 class Adsl(Device): pass
@@ -395,6 +401,12 @@ class Vxlan(Device): pass
 class Wimax(Device): pass
 class Wired(Device): pass
 class Wireless(Device): pass
+class MacSec(Device): pass
+class Dummy(Device): pass
+class PPP(Device): pass
+class OvsIf(Device): pass
+class OvsPort(Device): pass
+class OvsBridge(Device): pass
 
 class NSP(TransientNMDbusInterface):
     interface_names = ['org.freedesktop.NetworkManager.Wimax.NSP']
@@ -746,6 +758,12 @@ NM_DEVICE_TYPE_IP_TUNNEL = 17
 NM_DEVICE_TYPE_MACVLAN = 18
 NM_DEVICE_TYPE_VXLAN = 19
 NM_DEVICE_TYPE_VETH = 20
+NM_DEVICE_TYPE_MACSEC = 21
+NM_DEVICE_TYPE_DUMMY = 22
+NM_DEVICE_TYPE_PPP = 23
+NM_DEVICE_TYPE_OVS_INTERFACE = 24
+NM_DEVICE_TYPE_OVS_PORT = 25
+NM_DEVICE_TYPE_OVS_BRIDGE = 26
 NM_DEVICE_CAP_NONE = 0
 NM_DEVICE_CAP_NM_SUPPORTED = 1
 NM_DEVICE_CAP_CARRIER_DETECT = 2


### PR DESCRIPTION
The following device types/classes where missing:

    MACSEC
    Dummy
    PPP
    OVS_INTERFACE
    OVS_PORT
    OVS_BRIDGE

This pull request adds them all.