### PR TITLE
Added additional handler to_dbus() fixup

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -477,6 +477,12 @@ class fixups(object):
             if 'ssid' in settings.get('802-11-wireless', {}):
                 settings['802-11-wireless']['ssid'] = fixups.ssid_to_dbus(settings['802-11-wireless']['ssid'])
             if 'ipv4' in settings:
+                if 'address-data' in settings['ipv4']:
+                    for item in settings['ipv4']['address-data']:
+                        item['prefix'] = dbus.UInt32(item['prefix'])
+                    settings['ipv4']['address-data'] = dbus.Array(
+                        settings['ipv4']['address-data'],
+                        signature=dbus.Signature('a{sv}'))
                 if 'addresses' in settings['ipv4']:
                     settings['ipv4']['addresses'] = [fixups.addrconf_to_dbus(addr,socket.AF_INET) for addr in settings['ipv4']['addresses']]
                 if 'routes' in settings['ipv4']:


### PR DESCRIPTION
Specific fixup for settings.connection.address-data fields, as
these resulted in the following error:

dbus.connection: unable to set arguments ... according to
signature 'a{sa{sv}}': <class 'TypeError'>: Expected a string
or unicode object

Fixes issue #40.