### PR TITLE
Another Fix for #68 #76 - Add new devices type

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -389,7 +389,11 @@ def device_class(typ):
         NM_DEVICE_TYPE_PPP: PPP,
         NM_DEVICE_TYPE_OVS_INTERFACE: OvsIf,
         NM_DEVICE_TYPE_OVS_PORT: OvsPort,
-        NM_DEVICE_TYPE_OVS_BRIDGE: OvsBridge
+        NM_DEVICE_TYPE_OVS_BRIDGE: OvsBridge,
+        NM_DEVICE_TYPE_WPAN: Wpan,
+        NM_DEVICE_TYPE_6LOWPAN: SixLoWpan,
+        NM_DEVICE_TYPE_WIREGUARD: WireGuard,
+        NM_DEVICE_TYPE_WIFI_P2P: WifiP2p
     }[typ]
 
 class Adsl(Device): pass
@@ -416,6 +420,10 @@ class PPP(Device): pass
 class OvsIf(Device): pass
 class OvsPort(Device): pass
 class OvsBridge(Device): pass
+class Wpan(Device): pass
+class SixLoWpan(Device): pass
+class WireGuard(Device): pass
+class WifiP2p(Device): pass
 
 class NSP(TransientNMDbusInterface):
     interface_names = ['org.freedesktop.NetworkManager.Wimax.NSP']
@@ -780,6 +788,10 @@ NM_DEVICE_TYPE_PPP = 23
 NM_DEVICE_TYPE_OVS_INTERFACE = 24
 NM_DEVICE_TYPE_OVS_PORT = 25
 NM_DEVICE_TYPE_OVS_BRIDGE = 26
+NM_DEVICE_TYPE_WPAN = 27
+NM_DEVICE_TYPE_6LOWPAN = 28
+NM_DEVICE_TYPE_WIREGUARD = 29
+NM_DEVICE_TYPE_WIFI_P2P = 30
 NM_DEVICE_CAP_NONE = 0
 NM_DEVICE_CAP_NM_SUPPORTED = 1
 NM_DEVICE_CAP_CARRIER_DETECT = 2


### PR DESCRIPTION
According to the NetworkManager documentation:
https://developer.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMDeviceType

There is 4 new device type:
```
NM_DEVICE_TYPE_WPAN      = 27 - a IEEE 802.15.4 (WPAN) MAC Layer Device
NM_DEVICE_TYPE_6LOWPAN   = 28 - 6LoWPAN interface
NM_DEVICE_TYPE_WIREGUARD = 29 - a WireGuard interface
NM_DEVICE_TYPE_WIFI_P2P  = 30 - an 802.11 Wi-Fi P2P device (Since: 1.16)
```

This changes add contants and classes for these devices and add them
in the device_class dict.

Fix #68 #76
See also #80