### PR TITLE
Don't assume that the `dns` field is present in the `GetSettings` D-Bus reply

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -614,13 +614,19 @@ class fixups(object):
                 if 'bssid' in val_:
                     val_['bssid'] = fixups.mac_to_python(val_['bssid'])
             if 'ipv4' in val:
-                val['ipv4']['addresses'] = [fixups.addrconf_to_python(addr,socket.AF_INET) for addr in val['ipv4']['addresses']]
-                val['ipv4']['routes'] = [fixups.route_to_python(route,socket.AF_INET) for route in val['ipv4']['routes']]
-                val['ipv4']['dns'] = [fixups.addr_to_python(addr,socket.AF_INET) for addr in val['ipv4']['dns']]
+                if 'addresses' in val['ipv4']:
+                    val['ipv4']['addresses'] = [fixups.addrconf_to_python(addr,socket.AF_INET) for addr in val['ipv4']['addresses']]
+                if 'routes' in val['ipv4']:
+                    val['ipv4']['routes'] = [fixups.route_to_python(route,socket.AF_INET) for route in val['ipv4']['routes']]
+                if 'dns' in val['ipv4']:
+                    val['ipv4']['dns'] = [fixups.addr_to_python(addr,socket.AF_INET) for addr in val['ipv4']['dns']]
             if 'ipv6' in val:
-                val['ipv6']['addresses'] = [fixups.addrconf_to_python(addr,socket.AF_INET6) for addr in val['ipv6']['addresses']]
-                val['ipv6']['routes'] = [fixups.route_to_python(route,socket.AF_INET6) for route in val['ipv6']['routes']]
-                val['ipv6']['dns'] = [fixups.addr_to_python(addr,socket.AF_INET6) for addr in val['ipv6']['dns']]
+                if 'addresses' in val['ipv6']:
+                    val['ipv6']['addresses'] = [fixups.addrconf_to_python(addr,socket.AF_INET6) for addr in val['ipv6']['addresses']]
+                if 'routes' in val['ipv6']:
+                    val['ipv6']['routes'] = [fixups.route_to_python(route,socket.AF_INET6) for route in val['ipv6']['routes']]
+                if 'dns' in val['ipv6']:
+                    val['ipv6']['dns'] = [fixups.addr_to_python(addr,socket.AF_INET6) for addr in val['ipv6']['dns']]
             return val
         if method == 'PropertiesChanged':
             for prop in val:


### PR DESCRIPTION
This has changed for Network Manager >= 1.34 with commit https://github.com/NetworkManager/NetworkManager/commit/d652e0f53487cf3f5b1f64038d9ff4a2f5947213.

While we're at it also don't assume that any of the other fields are present.

Fixes #93.